### PR TITLE
Tidied up cli

### DIFF
--- a/condax/cli/__init__.py
+++ b/condax/cli/__init__.py
@@ -1,70 +1,7 @@
-import logging
-from statistics import median
-import rainbowlog
-from pathlib import Path
-from typing import Callable, Optional
-
 import click
 
 import condax.config as config
 from condax import __version__
-
-
-option_config = click.option(
-    "--config",
-    "config_file",
-    type=click.Path(exists=True, path_type=Path),
-    help=f"Custom path to a condax config file in YAML. Default: {config.DEFAULT_CONFIG}",
-    callback=lambda _, __, f: (f and config.set_via_file(f)) or f,
-)
-
-option_channels = click.option(
-    "--channel",
-    "-c",
-    "channels",
-    multiple=True,
-    help=f"""Use the channels specified to install. If not specified condax will
-    default to using {config.DEFAULT_CHANNELS}, or 'channels' in the config file.""",
-    callback=lambda _, __, c: (c and config.set_via_value(channels=c)) or c,
-)
-
-option_envname = click.option(
-    "--name",
-    "-n",
-    "envname",
-    required=True,
-    prompt="Specify the environment (Run `condax list --short` to see available ones)",
-    type=str,
-    help=f"""Specify existing environment to inject into.""",
-    callback=lambda _, __, n: n.strip(),
-)
-
-option_is_forcing = click.option(
-    "-f",
-    "--force",
-    "is_forcing",
-    help="""Modify existing environment and files in CONDAX_BIN_DIR.""",
-    is_flag=True,
-    default=False,
-)
-
-
-def options_logging(f: Callable) -> Callable:
-    option_verbose = click.option(
-        "-v",
-        "--verbose",
-        count=True,
-        help="Raise verbosity level.",
-        callback=lambda _, __, v: _LoggerSetup.set_verbose(v),
-    )
-    option_quiet = click.option(
-        "-q",
-        "--quiet",
-        count=True,
-        help="Decrease verbosity level.",
-        callback=lambda _, __, q: _LoggerSetup.set_quiet(q),
-    )
-    return option_verbose(option_quiet(f))
 
 
 @click.group(
@@ -80,41 +17,6 @@ def options_logging(f: Callable) -> Callable:
     __version__,
     message="%(prog)s %(version)s",
 )
-@option_config
-@options_logging
+@click.help_option("-h", "--help")
 def cli(**_):
-    """Main entry point for condax."""
-    pass
-
-
-class _LoggerSetup:
-    handler = logging.StreamHandler()
-    formatter = rainbowlog.Formatter(logging.Formatter())
-    logger = logging.getLogger((__package__ or __name__).split(".", 1)[0])
-    verbose = 0
-    quiet = 0
-
-    @classmethod
-    def setup(cls) -> int:
-        """Setup the logger.
-
-        Returns:
-            int: The log level.
-        """
-        cls.handler.setFormatter(cls.formatter)
-        cls.logger.addHandler(cls.handler)
-        level = logging.INFO - 10 * (int(median((-1, 3, cls.verbose - cls.quiet))))
-        cls.logger.setLevel(level)
-        return level
-
-    @classmethod
-    def set_verbose(cls, v: int) -> int:
-        """Set the verbose level and return the new log level."""
-        cls.verbose += v
-        return cls.setup()
-
-    @classmethod
-    def set_quiet(cls, q: int):
-        """Set the quiet level and return the new log level."""
-        cls.quiet += q
-        return cls.setup()
+    return

--- a/condax/cli/ensure_path.py
+++ b/condax/cli/ensure_path.py
@@ -1,11 +1,8 @@
-from pathlib import Path
-from typing import Optional
-
 import condax.config as config
 import condax.paths as paths
 from condax import __version__
 
-from . import cli, option_config, options_logging
+from . import cli, options
 
 
 @cli.command(
@@ -13,7 +10,6 @@ from . import cli, option_config, options_logging
     Ensure the condax links directory is on $PATH.
     """
 )
-@option_config
-@options_logging
+@options.common
 def ensure_path(**_):
     paths.add_path_to_environment(config.C.bin_dir())

--- a/condax/cli/export.py
+++ b/condax/cli/export.py
@@ -4,7 +4,7 @@ import click
 import condax.core as core
 from condax import __version__
 
-from . import cli, option_is_forcing, options_logging
+from . import cli, options
 
 
 @cli.command(
@@ -17,9 +17,9 @@ from . import cli, option_is_forcing, options_logging
     default="condax_exported",
     help="Set directory to export to.",
 )
-@options_logging
-def export(dir: str, verbose: int, **_):
-    core.export_all_environments(dir, conda_stdout=verbose <= logging.INFO)
+@options.common
+def export(dir: str, log_level: int, **_):
+    core.export_all_environments(dir, conda_stdout=log_level <= logging.INFO)
 
 
 @cli.command(
@@ -28,14 +28,14 @@ def export(dir: str, verbose: int, **_):
     [experimental] Import condax environments.
     """,
 )
-@option_is_forcing
-@options_logging
+@options.is_forcing
+@options.common
 @click.argument(
     "directory",
     required=True,
     type=click.Path(exists=True, dir_okay=True, file_okay=False),
 )
-def run_import(directory: str, is_forcing: bool, verbose: int, **_):
+def run_import(directory: str, is_forcing: bool, log_level: int, **_):
     core.import_environments(
-        directory, is_forcing, conda_stdout=verbose <= logging.INFO
+        directory, is_forcing, conda_stdout=log_level <= logging.INFO
     )

--- a/condax/cli/inject.py
+++ b/condax/cli/inject.py
@@ -2,11 +2,10 @@ import logging
 from typing import List
 import click
 
-import condax.config as config
 import condax.core as core
 from condax import __version__
 
-from . import cli, option_channels, option_envname, option_is_forcing, options_logging
+from . import cli, options
 
 
 @cli.command(
@@ -14,23 +13,23 @@ from . import cli, option_channels, option_envname, option_is_forcing, options_l
     Inject a package to existing environment created by condax.
     """
 )
-@option_channels
-@option_envname
-@option_is_forcing
+@options.channels
+@options.envname
+@options.is_forcing
 @click.option(
     "--include-apps",
     help="""Make apps from the injected package available.""",
     is_flag=True,
     default=False,
 )
-@options_logging
-@click.argument("packages", nargs=-1, required=True)
+@options.common
+@options.packages
 def inject(
     packages: List[str],
     envname: str,
     is_forcing: bool,
     include_apps: bool,
-    verbose: int,
+    log_level: int,
     **_,
 ):
     core.inject_package_to(
@@ -38,7 +37,7 @@ def inject(
         packages,
         is_forcing=is_forcing,
         include_apps=include_apps,
-        conda_stdout=verbose <= logging.INFO,
+        conda_stdout=log_level <= logging.INFO,
     )
 
 
@@ -47,8 +46,8 @@ def inject(
     Uninject a package from an existing environment.
     """
 )
-@option_envname
-@options_logging
-@click.argument("packages", nargs=-1, required=True)
-def uninject(packages: List[str], envname: str, verbose: int, **_):
-    core.uninject_package_from(envname, packages, verbose <= logging.INFO)
+@options.envname
+@options.common
+@options.packages
+def uninject(packages: List[str], envname: str, log_level: int, **_):
+    core.uninject_package_from(envname, packages, log_level <= logging.INFO)

--- a/condax/cli/install.py
+++ b/condax/cli/install.py
@@ -7,14 +7,7 @@ import condax.config as config
 import condax.core as core
 from condax import __version__
 
-from . import (
-    cli,
-    option_config,
-    option_channels,
-    option_is_forcing,
-    option_channels,
-    options_logging,
-)
+from . import cli, options
 
 
 @cli.command(
@@ -25,18 +18,17 @@ from . import (
     provided by it to `{config.DEFAULT_BIN_DIR}`.
     """
 )
-@option_channels
-@option_config
-@option_is_forcing
-@options_logging
-@click.argument("packages", nargs=-1)
+@options.channels
+@options.is_forcing
+@options.common
+@options.packages
 def install(
     packages: List[str],
     is_forcing: bool,
-    verbose: int,
+    log_level: int,
     **_,
 ):
     for pkg in packages:
         core.install_package(
-            pkg, is_forcing=is_forcing, conda_stdout=verbose <= logging.INFO
+            pkg, is_forcing=is_forcing, conda_stdout=log_level <= logging.INFO
         )

--- a/condax/cli/list.py
+++ b/condax/cli/list.py
@@ -3,7 +3,7 @@ import click
 import condax.core as core
 from condax import __version__
 
-from . import cli, options_logging
+from . import cli, options
 
 
 @cli.command(
@@ -27,6 +27,6 @@ from . import cli, options_logging
     default=False,
     help="Show packages injected into the main app's environment.",
 )
-@options_logging
+@options.common
 def run_list(short: bool, include_injected: bool, **_):
     core.list_all_packages(short=short, include_injected=include_injected)

--- a/condax/cli/options.py
+++ b/condax/cli/options.py
@@ -1,0 +1,118 @@
+import logging
+import rainbowlog
+from statistics import median
+from typing import Callable, Sequence
+from pathlib import Path
+
+from condax import config
+
+import click
+
+
+def common(f: Callable) -> Callable:
+    """
+    This decorator adds common options to the CLI.
+    """
+    options: Sequence[Callable] = (
+        config_file,
+        log_level,
+        click.help_option("-h", "--help"),
+    )
+
+    for op in options:
+        f = op(f)
+
+    return f
+
+
+packages = click.argument("packages", nargs=-1, required=True)
+
+config_file = click.option(
+    "--config",
+    "config_file",
+    type=click.Path(exists=True, path_type=Path),
+    help=f"Custom path to a condax config file in YAML. Default: {config.DEFAULT_CONFIG}",
+    callback=lambda _, __, f: (f and config.set_via_file(f)) or f,
+)
+
+channels = click.option(
+    "--channel",
+    "-c",
+    "channels",
+    multiple=True,
+    help=f"""Use the channels specified to install. If not specified condax will
+    default to using {config.DEFAULT_CHANNELS}, or 'channels' in the config file.""",
+    callback=lambda _, __, c: (c and config.set_via_value(channels=c)) or c,
+)
+
+envname = click.option(
+    "--name",
+    "-n",
+    "envname",
+    required=True,
+    prompt="Specify the environment (Run `condax list --short` to see available ones)",
+    type=str,
+    help=f"""Specify existing environment to inject into.""",
+    callback=lambda _, __, n: n.strip(),
+)
+
+is_forcing = click.option(
+    "-f",
+    "--force",
+    "is_forcing",
+    help="""Modify existing environment and files in CONDAX_BIN_DIR.""",
+    is_flag=True,
+    default=False,
+)
+
+verbose = click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Raise verbosity level.",
+)
+
+quiet = click.option(
+    "-q",
+    "--quiet",
+    count=True,
+    help="Decrease verbosity level.",
+)
+
+
+def log_level(f: Callable) -> Callable:
+    """
+    This click option decorator adds -v and -q options to the CLI, then sets up logging with the specified level.
+    It passes the level to the decorated function as `log_level`.
+    """
+
+    @verbose
+    @quiet
+    def setup_logging_hook(verbose: int, quiet: int, **kwargs):
+        handler = logging.StreamHandler()
+        logger = logging.getLogger((__package__ or __name__).split(".", 1)[0])
+        handler.setFormatter(rainbowlog.Formatter(logging.Formatter()))
+        logger.addHandler(handler)
+        level = int(
+            median(
+                (logging.DEBUG, logging.INFO - 10 * (verbose - quiet), logging.CRITICAL)
+            )
+        )
+        logger.setLevel(level)
+        return f(log_level=level, **kwargs)
+
+    # Since we replace the function with a wrapper, we need to pass some attributes on from the original function.
+    # click remembers all the options by setting __click_params__ on the function.
+    # click uses the name of the function by default as the name of the command.
+    try:
+        setattr(
+            setup_logging_hook,
+            "__click_params__",
+            getattr(f, "__click_params__")
+            + getattr(setup_logging_hook, "__click_params__"),
+        )
+    except AttributeError:
+        pass
+    setup_logging_hook.__name__ = f.__name__
+
+    return setup_logging_hook

--- a/condax/cli/remove.py
+++ b/condax/cli/remove.py
@@ -5,7 +5,7 @@ import click
 import condax.core as core
 from condax import __version__
 
-from . import cli, options_logging
+from . import cli, options
 
 
 @cli.command(
@@ -16,11 +16,11 @@ from . import cli, options_logging
     conda environment.
     """
 )
-@options_logging
-@click.argument("packages", nargs=-1)
-def remove(packages: List[str], verbose: int, **_):
+@options.common
+@options.packages
+def remove(packages: List[str], log_level: int, **_):
     for pkg in packages:
-        core.remove_package(pkg, conda_stdout=verbose <= logging.INFO)
+        core.remove_package(pkg, conda_stdout=log_level <= logging.INFO)
 
 
 @cli.command(
@@ -28,7 +28,7 @@ def remove(packages: List[str], verbose: int, **_):
     Alias for condax remove.
     """
 )
-@options_logging
-@click.argument("packages", nargs=-1)
+@options.common
+@options.packages
 def uninstall(packages: List[str], **_):
     remove(packages)

--- a/condax/cli/repair.py
+++ b/condax/cli/repair.py
@@ -6,7 +6,7 @@ import condax.core as core
 import condax.migrate as migrate
 from condax import __version__
 
-from . import cli, options_logging
+from . import cli, options
 
 
 @cli.command(
@@ -23,7 +23,7 @@ from . import cli, options_logging
     is_flag=True,
     default=False,
 )
-@options_logging
+@options.common
 def repair(is_migrating, **_):
     if is_migrating:
         migrate.from_old_version()

--- a/condax/cli/update.py
+++ b/condax/cli/update.py
@@ -7,7 +7,7 @@ import click
 import condax.core as core
 from condax import __version__
 
-from . import cli, options_logging
+from . import cli, options
 
 
 @cli.command(
@@ -23,7 +23,7 @@ from . import cli, options_logging
 @click.option(
     "--update-specs", is_flag=True, help="Update based on provided specifications."
 )
-@options_logging
+@options.common
 @click.argument("packages", required=False, nargs=-1)
 @click.pass_context
 def update(
@@ -31,13 +31,15 @@ def update(
     all: bool,
     packages: List[str],
     update_specs: bool,
-    verbose: int,
+    log_level: int,
     **_
 ):
     if all:
         core.update_all_packages(update_specs)
     elif packages:
         for pkg in packages:
-            core.update_package(pkg, update_specs, conda_stdout=verbose <= logging.INFO)
+            core.update_package(
+                pkg, update_specs, conda_stdout=log_level <= logging.INFO
+            )
     else:
         ctx.fail("No packages specified.")

--- a/condax/utils.py
+++ b/condax/utils.py
@@ -71,7 +71,7 @@ def is_executable(path: Path) -> bool:
             for ext in os.environ.get("PATHEXT", "").split(os.pathsep)
         ]
         ext = path.suffix.lower()
-        return ext and (ext in pathexts)
+        return bool(ext) and (ext in pathexts)
 
     return os.access(path, os.X_OK)
 


### PR DESCRIPTION
* Put options in their own file
* Better mechanism for -q and -v flags
* Added `options.common` decorator which adds -v, -q, --config, and short -h flag (by default click only supports long version --help)