### PR TITLE
Fix TypeError when --channel is specified in CLI

### DIFF
--- a/condax/cli/options.py
+++ b/condax/cli/options.py
@@ -43,7 +43,7 @@ channels = click.option(
     multiple=True,
     help=f"""Use the channels specified to install. If not specified condax will
     default to using {config.DEFAULT_CHANNELS}, or 'channels' in the config file.""",
-    callback=lambda _, __, c: (c and config.set_via_value(channels=c)) or c,
+    callback=lambda _, __, c: (c and config.set_via_value(channels=list(c))) or c,
 )
 
 envname = click.option(


### PR DESCRIPTION
There is a bug raising `TypeError: can only concatenate tuple (not "list") to tuple` when `--channel` is specified. 

For example
```shell
condax install -c conda-forge jq
```


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
