### PR TITLE
Enable installing via conda environment YAML file

### DIFF
--- a/condax/cli/install.py
+++ b/condax/cli/install.py
@@ -1,11 +1,11 @@
 import logging
-from typing import List
+from pathlib import Path
+from typing import List, Optional
 
 import click
 
 import condax.config as config
 import condax.core as core
-from condax import __version__
 
 from . import cli, options
 
@@ -20,14 +20,33 @@ from . import cli, options
 )
 @options.channels
 @options.is_forcing
+@click.option(
+    "--file",
+    "envfile",
+    type=click.Path(exists=True, path_type=Path),
+    help=f"Specify Conda environment file in YAML.",
+    default=None,
+)
 @options.common
 @options.packages
 def install(
     packages: List[str],
     is_forcing: bool,
     log_level: int,
+    envfile: Optional[Path],
     **_,
-):
+) -> None:
+
+    if envfile:
+        core.install_via_env_file(
+            envfile,
+            packages,
+            is_forcing=is_forcing,
+            conda_stdout=log_level <= logging.INFO,
+        )
+
+        return
+
     for pkg in packages:
         core.install_package(
             pkg, is_forcing=is_forcing, conda_stdout=log_level <= logging.INFO

--- a/condax/conda.py
+++ b/condax/conda.py
@@ -375,11 +375,12 @@ def export_env(env_name: str, out_dir: Path, stdout: bool = False) -> None:
     )
 
 
-def import_env(env_file: Path, is_forcing: bool = False, stdout: bool = False) -> None:
+def import_env(env_file: Path, is_forcing: bool = False, stdout: bool = False, env_name: Optional[str] = None) -> None:
     """Import an environment from a conda environment file."""
     conda_exe = ensure_conda()
     force_args = ["--force"] if is_forcing else []
-    env_name = env_file.stem
+    if env_name is None:
+        env_name = env_file.stem
     prefix = conda_env_prefix(env_name)
     _subprocess_run(
         [

--- a/condax/utils.py
+++ b/condax/utils.py
@@ -5,6 +5,8 @@ from typing import List, Tuple, Union
 import re
 import urllib.parse
 
+import yaml
+
 from condax.exceptions import CondaxError
 
 
@@ -184,3 +186,21 @@ def is_env_dir(path: Union[Path, str]) -> bool:
     """Check if a path is a conda environment directory."""
     p = to_path(path)
     return (p / "conda-meta" / "history").exists()
+
+
+def get_env_dependencies(path: Path) -> List[str]:
+    """Get a list of dependent packages in conda environment in YAML
+
+    Arguments:
+        path: path to the conda environment YAML file
+
+    Returns:
+        a list of dependencies package names
+    """
+
+    with path.open() as f:
+        d = yaml.safe_load(f)
+
+    specs = d.get("dependencies", [])
+    packages = [split_match_specs(spec)[0] for spec in specs]
+    return packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "condax"
-version = "1.0.0"
+version = "1.1.0"
 description = "Install and run applications packaged with conda in isolated environments"
 authors = [
 	"Marius van Niekerk <marius.v.niekerk@gmail.com>",


### PR DESCRIPTION
Effectively this patch adds `--file <env-file>` option to `condax install`.

Package name(s) must be supplied because it is the only way for `condax` to select paths to the executable files described in `conda-meta` directory.

Example usage: The executable `qiime` is provided by the `q2cli` package though the YAML file specifies many dependencies. ([qiime2 doc](https://docs.qiime2.org/2022.8/install/native/#install-qiime-2-within-a-conda-environment))

```shell
wget https://data.qiime2.org/distro/core/qiime2-2022.8-py38-linux-conda.yml -O qiime2.yml
condax install --file qiime2.yml q2cli
```

