### PR TITLE
Exclude executables that start with '.' or '_'

### DIFF
--- a/condax/conda.py
+++ b/condax/conda.py
@@ -258,6 +258,8 @@ def determine_executables_from_env(
         p = to_path(p)
         res = (p.parent.name in ("bin", "sbin", "scripts", "Scripts")) and (
             p.suffix not in EXCLUCDED_FILE_EXTENSIONS
+        ) and (
+            not p.name.startswith(".") and not p.name.startswith("_")
         )
         return res
 


### PR DESCRIPTION
Bioconda packages often contain "garbage" files as executables, and their names often starts with dot (like dotfiles), or underscore. So, this fix excludes such files from `condax` management.